### PR TITLE
Enabled use of pixel_format and white_balance roslaunch args.

### DIFF
--- a/launch/single_node.launch
+++ b/launch/single_node.launch
@@ -44,6 +44,7 @@
 
     <param name="fps" type="double" value="$(arg fps)"/>
     <param name="video_mode" type="int" value="$(arg video_mode)"/>
+    <param name="pixel_format" type="int" value="$(arg pixel_format)"/>
     <param name="exposure" type="bool" value="$(arg exposure)"/>
     <param name="auto_exposure" type="bool" value="$(arg auto_exposure)"/>
     <param name="auto_shutter" type="bool" value="$(arg auto_shutter)"/>
@@ -58,6 +59,8 @@
     <param name="auto_white_balance" type="bool" value="$(arg auto_white_balance)"/>
     <param name="width" type="int" value="$(arg width)"/>
     <param name="height" type="int" value="$(arg height)"/>
+    <param name="white_balance" type="bool" value="$(arg white_balance)" />
+    <param name="auto_white_balance" type="bool" value="$(arg auto_white_balance)" />
   </node>
 
   <!-- Extras -->

--- a/launch/stereo_node.launch
+++ b/launch/stereo_node.launch
@@ -50,6 +50,7 @@
         <param name="frame_id" type="string" value="$(arg frame_id)"/>
         <param name="fps" type="double" value="$(arg fps)"/>
         <param name="video_mode" type="int" value="$(arg video_mode)"/>
+        <param name="pixel_format" type="int" value="$(arg pixel_format)"/>
         <param name="exposure" type="bool" value="$(arg exposure)"/>
         <param name="auto_exposure" type="bool" value="$(arg auto_exposure)"/>
         <param name="auto_shutter" type="bool" value="$(arg auto_shutter)"/>
@@ -59,6 +60,8 @@
         <param name="trigger_source" type="int" value="$(arg trigger_source)"/>
         <param name="width" type="int" value="$(arg width)"/>
         <param name="height" type="int" value="$(arg height)"/>
+        <param name="white_balance" type="bool" value="$(arg white_balance)" />
+        <param name="auto_white_balance" type="bool" value="$(arg auto_white_balance)" />
     </node>
 
     <!-- Proc -->


### PR DESCRIPTION
Args previously existed to the launch file but the launch file was previously not passing it along as a parameter to the node. 
