### PR TITLE
added feature to do non-blocking frame grab.

### DIFF
--- a/include/flea3/flea3_camera.h
+++ b/include/flea3/flea3_camera.h
@@ -21,6 +21,7 @@ class Flea3Camera {
   const unsigned serial_id() const { return std::atoi(serial_.c_str()); }
 
   bool GrabImage(sensor_msgs::Image& image_msg);
+  bool GrabImageNonBlocking(sensor_msgs::Image& image_msg);
 //  void GrabImageMetadata(flea3::ImageMetadata& image_metadata_msg);
 
   bool Connect();
@@ -72,6 +73,10 @@ class Flea3Camera {
   void SetStrobe(int& strobe_control, int& polarity);
   void TurnOffStrobe(const std::vector<int>& strobes);
 
+  // Blocking/Non-blocking
+  void setNonBlocking();
+  void setBlocking();
+  
   bool capturing_{false};
   BusManager bus_manager_;
   Camera camera_;

--- a/include/flea3/flea3_ros.h
+++ b/include/flea3/flea3_ros.h
@@ -17,6 +17,8 @@ class Flea3Ros : public camera_base::CameraRosBase {
 
   bool Grab(const sensor_msgs::ImagePtr& image_msg,
             const sensor_msgs::CameraInfoPtr& cinfo_msg = nullptr) override;
+  bool GrabNonBlocking(const sensor_msgs::ImagePtr& image_msg,
+                       const sensor_msgs::CameraInfoPtr& cinfo_msg = nullptr);
   void PublishImageMetadata(const ros::Time& time);
 
   void Stop();

--- a/src/flea3_camera.cpp
+++ b/src/flea3_camera.cpp
@@ -208,6 +208,27 @@ void Flea3Camera::SetFrameRate(double& frame_rate) {
   }
 }
 
+void Flea3Camera::setNonBlocking() {
+  FC2Config config;
+  PgrError(camera_.GetConfiguration(&config), "Failed to get configuration");
+  config.grabTimeout = TIMEOUT_NONE; // return immediately
+  PgrError(camera_.SetConfiguration(&config), "Failed to set configuration");
+}
+
+void Flea3Camera::setBlocking() {
+  FC2Config config;
+  PgrError(camera_.GetConfiguration(&config), "Failed to get configuration");
+  config.grabTimeout = 1000; // set to one second;
+  PgrError(camera_.SetConfiguration(&config), "Failed to set configuration");
+}
+
+bool Flea3Camera::GrabImageNonBlocking(sensor_msgs::Image& image_msg) {
+  setNonBlocking();
+  bool ret = GrabImage(image_msg);
+  setBlocking();
+  return (ret);
+}
+
 bool Flea3Camera::GrabImage(sensor_msgs::Image& image_msg) {
   if (!(camera_.IsConnected() && capturing_)) return false;
 

--- a/src/flea3_ros.cpp
+++ b/src/flea3_ros.cpp
@@ -14,6 +14,11 @@ bool Flea3Ros::Grab(const sensor_msgs::ImagePtr& image_msg,
   return flea3_.GrabImage(*image_msg);
 }
 
+bool Flea3Ros::GrabNonBlocking(const sensor_msgs::ImagePtr& image_msg,
+                               const sensor_msgs::CameraInfoPtr& cinfo_msg) {
+  return flea3_.GrabImageNonBlocking(*image_msg);
+}
+
 // void Flea3Ros::PublishImageMetadata(const ros::Time& time) {
 //  auto image_metadata_msg = boost::make_shared<ImageMetadata>();
 //  flea3_.GrabImageMetadata(*image_metadata_msg);


### PR DESCRIPTION
I needed this feature to drain frames in situations where I was syncing multiple cameras. Sometimes you want to make sure there is no frame waiting to be picked up, but you don't want to block to find out. The nonblocking grab will allow you to do just that: grab the frame if there is one, but don't block if the buffer is empty.
