### PR TITLE
allow enabling of output voltage on blackfly GPIO pin 3

### DIFF
--- a/cfg/Flea3Dyn.cfg
+++ b/cfg/Flea3Dyn.cfg
@@ -100,6 +100,9 @@ strobe_polarity_enum = gen.enum([gen.const("sc_low", int_t, 0, "low"),
 gen.add("strobe_polarity", int_t, 0,
         "Strobe polarity",
         0, 0, 1, edit_method=strobe_polarity_enum)
+gen.add("enable_output_voltage", bool_t, 0,
+        "Enable 3.3V output voltage on GPIO pin3 (blackfly)",
+        False)
 
 # Exposure
 # 1. Off: Control of the exposure is achieved via setting both Exposure and

--- a/include/flea3/flea3_camera.h
+++ b/include/flea3/flea3_camera.h
@@ -72,7 +72,8 @@ class Flea3Camera {
   // Strobe
   void SetStrobe(int& strobe_control, int& polarity);
   void TurnOffStrobe(const std::vector<int>& strobes);
-
+  void EnableOutputVoltage(bool enabled);
+  
   // Blocking/Non-blocking
   void setNonBlocking();
   void setBlocking();


### PR DESCRIPTION
The blackfly cameras offer 3.3V on GPIO pin 3, but that needs to be enabled by setting a register.
This PR adds a feature to enable the 3.3V output.

 